### PR TITLE
Cfg to cvar

### DIFF
--- a/common/main/config.h
+++ b/common/main/config.h
@@ -37,32 +37,37 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 
 struct Cfg : prohibit_void_ptr<Cfg>
 {
-	ubyte DigiVolume;
-	ubyte MusicVolume;
-	int ReverseStereo;
-	int OrigTrackOrder;
-	int MusicType;
-	int CMLevelMusicPlayOrder;
-	int CMLevelMusicTrack[2];
-	ntstring<PATH_MAX - 1> CMLevelMusicPath;
-	array<ntstring<PATH_MAX - 1>, 5> CMMiscMusic;
-	int GammaLevel;
-	callsign_t LastPlayer;
-	char LastMission[MISSION_NAME_LEN+1];
-	int ResolutionX;
-	int ResolutionY;
-	int AspectX;
-	int AspectY;
-	int WindowMode;
-	int TexFilt;
-	int VSync;
-	int Multisample;
-	int FPSIndicator;
-	int Grabinput;
-#ifdef DXX_BUILD_DESCENT_II
-	int MovieTexFilt;
-	int MovieSubtitles;
+	cvar_t DigiVolume             = { "DigiVolume",            "0", CVAR_ARCHIVE };
+	cvar_t MusicVolume            = { "MusicVolume",           "0", CVAR_ARCHIVE };
+	cvar_t ReverseStereo          = { "ReverseStereo",         "0", CVAR_ARCHIVE };
+	cvar_t OrigTrackOrder         = { "OrigTrackOrder",        "0", CVAR_ARCHIVE };
+	cvar_t MusicType              = { "MusicType",             "0", CVAR_ARCHIVE };
+	cvar_t CMLevelMusicPlayOrder  = { "CMLevelMusicPlayOrder", "0", CVAR_ARCHIVE };
+	cvar_t CMLevelMusicTrack[2] = { { "CMLevelMusicTrack0",    "0", CVAR_ARCHIVE },
+	                                { "CMLevelMusicTrack1",    "0", CVAR_ARCHIVE } };
+	cvar_t CMLevelMusicPath       = { "CMLevelMusicPath",      "0", CVAR_ARCHIVE };
+	cvar_t CMMiscMusic[5]       = { { "CMMiscMusic0",          "0", CVAR_ARCHIVE },
+	                                { "CMMiscMusic1",          "0", CVAR_ARCHIVE },
+	                                { "CMMiscMusic2",          "0", CVAR_ARCHIVE },
+	                                { "CMMiscMusic3",          "0", CVAR_ARCHIVE },
+	                                { "CMMiscMusic4",          "0", CVAR_ARCHIVE } };
+	cvar_t GammaLevel             = { "GammaLevel",            "0", CVAR_ARCHIVE };
+	cvar_t LastPlayer             = { "LastPlayer",            "0", CVAR_ARCHIVE };
+	cvar_t LastMission            = { "LastMission",           "0", CVAR_ARCHIVE };
+	cvar_t ResolutionX            = { "ResolutionX",           "0", CVAR_ARCHIVE };
+	cvar_t ResolutionY            = { "ResolutionY",           "0", CVAR_ARCHIVE };
+	cvar_t AspectX                = { "AspectX",               "0", CVAR_ARCHIVE };
+	cvar_t AspectY                = { "AspectY",               "0", CVAR_ARCHIVE };
+	cvar_t WindowMode             = { "WindowMode",            "0", CVAR_ARCHIVE };
+	cvar_t TexFilt                = { "TexFilt",               "0", CVAR_ARCHIVE };
+#if defined(DXX_BUILD_DESCENT_II)
+	cvar_t MovieTexFilt           = { "MovieTexFilt",          "0", CVAR_ARCHIVE };
+	cvar_t MovieSubtitles         = { "MovieSubtitles",        "0", CVAR_ARCHIVE };
 #endif
+	cvar_t VSync                  = { "VSync",                 "0", CVAR_ARCHIVE };
+	cvar_t Multisample            = { "Multisample",           "0", CVAR_ARCHIVE };
+	cvar_t FPSIndicator           = { "FPSIndicator",          "0", CVAR_ARCHIVE };
+	cvar_t Grabinput              = { "GrabInput",             "0", CVAR_ARCHIVE };
 };
 
 extern struct Cfg GameCfg;

--- a/similar/main/config.cpp
+++ b/similar/main/config.cpp
@@ -247,42 +247,17 @@ int ReadConfigFile()
 int WriteConfigFile()
 {
 	GameCfg.GammaLevel = gr_palette_get_gamma();
+	GameCfg.LastPlayer = Players[Player_num].callsign;
+	GameCfg.ResolutionX = SM_W(Game_screen_mode);
+	GameCfg.ResolutionY = SM_H(Game_screen_mode);
 
 	auto infile = PHYSFSX_openWriteBuffered("descent.cfg");
 	if (!infile)
 	{
 		return 1;
 	}
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.DigiVolume.name, static_cast<int>(GameCfg.DigiVolume));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.MusicVolume.name, static_cast<int>(GameCfg.MusicVolume));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.ReverseStereo.name, static_cast<int>(GameCfg.ReverseStereo));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.OrigTrackOrder.name, static_cast<int>(GameCfg.OrigTrackOrder));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.MusicType.name, static_cast<int>(GameCfg.MusicType));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.CMLevelMusicPlayOrder.name, static_cast<int>(GameCfg.CMLevelMusicPlayOrder));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.CMLevelMusicTrack[0].name, static_cast<int>(GameCfg.CMLevelMusicTrack[0]));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.CMLevelMusicTrack[1].name, static_cast<int>(GameCfg.CMLevelMusicTrack[1]));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.CMLevelMusicPath.name, static_cast<const char *>(GameCfg.CMLevelMusicPath));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.CMMiscMusic[SONG_TITLE].name, static_cast<const char *>(GameCfg.CMMiscMusic[SONG_TITLE]));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.CMMiscMusic[SONG_BRIEFING].name, static_cast<const char *>(GameCfg.CMMiscMusic[SONG_BRIEFING]));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.CMMiscMusic[SONG_ENDLEVEL].name, static_cast<const char *>(GameCfg.CMMiscMusic[SONG_ENDLEVEL]));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.CMMiscMusic[SONG_ENDGAME].name, static_cast<const char *>(GameCfg.CMMiscMusic[SONG_ENDGAME]));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.CMMiscMusic[SONG_CREDITS].name, static_cast<const char *>(GameCfg.CMMiscMusic[SONG_CREDITS]));
-	PHYSFSX_printf(infile, "%s=%d\n", GameCfg.GammaLevel.name, static_cast<int>(GameCfg.GammaLevel));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.LastPlayer.name, static_cast<const char *>(Players[Player_num].callsign));
-	PHYSFSX_printf(infile, "%s=%s\n", GameCfg.LastMission.name, static_cast<const char *>(GameCfg.LastMission));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.ResolutionX.name, SM_W(Game_screen_mode));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.ResolutionY.name, SM_H(Game_screen_mode));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.AspectX.name, static_cast<int>(GameCfg.AspectX));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.AspectY.name, static_cast<int>(GameCfg.AspectY));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.WindowMode.name, static_cast<int>(GameCfg.WindowMode));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.TexFilt.name, static_cast<int>(GameCfg.TexFilt));
-#if defined(DXX_BUILD_DESCENT_II)
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.MovieTexFilt.name, static_cast<int>(GameCfg.MovieTexFilt));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.MovieSubtitles.name, static_cast<int>(GameCfg.MovieSubtitles));
-#endif
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.VSync.name, static_cast<int>(GameCfg.VSync));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.Multisample.name, static_cast<int>(GameCfg.Multisample));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.FPSIndicator.name, static_cast<int>(GameCfg.FPSIndicator));
-	PHYSFSX_printf(infile, "%s=%i\n", GameCfg.Grabinput.name, static_cast<int>(GameCfg.Grabinput));
+
+	cvar_write(infile);
+
 	return 0;
 }

--- a/similar/main/config.cpp
+++ b/similar/main/config.cpp
@@ -148,93 +148,17 @@ int ReadConfigFile()
 	GameCfg.Grabinput = 1;
 
 
-	auto infile = PHYSFSX_openReadBuffered("descent.cfg");
-	if (!infile)
+	if (!PHYSFSX_exists("descent.cfg", 1))
 	{
 		return 1;
 	}
 
-	// to be fully safe, assume the whole cfg consists of one big line
-	for (PHYSFSX_gets_line_t<0> line(PHYSFS_fileLength(infile) + 1); !PHYSFS_eof(infile);)
-	{
-		PHYSFSX_fgets(line, infile);
-		const auto lb = line.begin();
-		const auto eol = std::find(lb, line.end(), 0);
-		if (eol == line.end())
-			continue;
-		auto eq = std::find(lb, eol, '=');
-		if (eq == eol)
-			continue;
-		auto value = std::next(eq);
-		if (!d_stricmp(lb, GameCfg.DigiVolume.name))
-			GameCfg.DigiVolume = value;
-		else if (!d_stricmp(lb, GameCfg.MusicVolume.name))
-			GameCfg.MusicVolume = value;
-		else if (!d_stricmp(lb, GameCfg.ReverseStereo.name))
-			GameCfg.ReverseStereo = value;
-		else if (!d_stricmp(lb, GameCfg.OrigTrackOrder.name))
-			GameCfg.OrigTrackOrder = value;
-		else if (!d_stricmp(lb, GameCfg.MusicType.name))
-			GameCfg.MusicType = value;
-		else if (!d_stricmp(lb, GameCfg.CMLevelMusicPlayOrder.name))
-			GameCfg.CMLevelMusicPlayOrder = value;
-		else if (!d_stricmp(lb, GameCfg.CMLevelMusicTrack[0].name))
-			GameCfg.CMLevelMusicTrack[0] = value;
-		else if (!d_stricmp(lb, GameCfg.CMLevelMusicTrack[1].name))
-			GameCfg.CMLevelMusicTrack[1] = value;
-		else if (!d_stricmp(lb, GameCfg.CMLevelMusicPath.name))
-			GameCfg.CMLevelMusicPath = value;
-		else if (!d_stricmp(lb, GameCfg.CMMiscMusic[SONG_TITLE].name))
-			GameCfg.CMMiscMusic[SONG_TITLE] = value;
-		else if (!d_stricmp(lb, GameCfg.CMMiscMusic[SONG_BRIEFING].name))
-			GameCfg.CMMiscMusic[SONG_BRIEFING] = value;
-		else if (!d_stricmp(lb, GameCfg.CMMiscMusic[SONG_ENDLEVEL].name))
-			GameCfg.CMMiscMusic[SONG_ENDLEVEL] = value;
-		else if (!d_stricmp(lb, GameCfg.CMMiscMusic[SONG_ENDGAME].name))
-			GameCfg.CMMiscMusic[SONG_ENDGAME] = value;
-		else if (!d_stricmp(lb, GameCfg.CMMiscMusic[SONG_CREDITS].name))
-			GameCfg.CMMiscMusic[SONG_CREDITS] = value;
-		else if (!d_stricmp(lb, GameCfg.GammaLevel.name))
-		{
-			GameCfg.GammaLevel = value;
-			gr_palette_set_gamma( GameCfg.GammaLevel );
-		}
-		else if (!d_stricmp(lb, GameCfg.LastPlayer.name))
-		{
-			char temp[CALLSIGN_LEN + 1];
-			strncpy(temp, value, CALLSIGN_LEN + 1);
-			d_strlwr(temp);
-			GameCfg.LastPlayer = temp;
-		}
-		else if (!d_stricmp(lb, GameCfg.LastMission.name))
-			GameCfg.LastMission = value;
-		else if (!d_stricmp(lb, GameCfg.ResolutionX.name))
-			GameCfg.ResolutionX = value;
-		else if (!d_stricmp(lb, GameCfg.ResolutionY.name))
-			GameCfg.ResolutionY = value;
-		else if (!d_stricmp(lb, GameCfg.AspectX.name))
-			GameCfg.AspectX = value;
-		else if (!d_stricmp(lb, GameCfg.AspectY.name))
-			GameCfg.AspectY = value;
-		else if (!d_stricmp(lb, GameCfg.WindowMode.name))
-			GameCfg.WindowMode = value;
-		else if (!d_stricmp(lb, GameCfg.TexFilt.name))
-			GameCfg.TexFilt = value;
-#if defined(DXX_BUILD_DESCENT_II)
-		else if (!d_stricmp(lb, GameCfg.MovieTexFilt.name))
-			GameCfg.MovieTexFilt = value;
-		else if (!d_stricmp(lb, GameCfg.MovieSubtitles.name))
-			GameCfg.MovieSubtitles = value;
-#endif
-		else if (!d_stricmp(lb, GameCfg.VSync.name))
-			GameCfg.VSync = value;
-		else if (!d_stricmp(lb, GameCfg.Multisample.name))
-			GameCfg.Multisample = value;
-		else if (!d_stricmp(lb, GameCfg.FPSIndicator.name))
-			GameCfg.FPSIndicator = value;
-		else if (!d_stricmp(lb, GameCfg.Grabinput.name))
-			GameCfg.Grabinput = value;
-	}
+	cmd_append("exec descent.cfg");
+	cmd_queue_flush();
+
+
+	gr_palette_set_gamma( GameCfg.GammaLevel );
+
 	if ( GameCfg.DigiVolume > 8 ) GameCfg.DigiVolume = 8;
 	if ( GameCfg.MusicVolume > 8 ) GameCfg.MusicVolume = 8;
 

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -354,7 +354,7 @@ int RegisterPlayer()
 		else
 		{
 			// Read the last player's name from config file, not lastplr.txt
-			Players[Player_num].callsign = GameCfg.LastPlayer;
+			Players[Player_num].callsign.copy(GameCfg.LastPlayer, CALLSIGN_LEN - 1);
 		}
 	}
 
@@ -923,7 +923,7 @@ void change_res()
 	nm_set_item_input(m[mc], crestext);
 	modes[mc] = 0; mc++;
 	nm_set_item_text(m[mc], "aspect:"); mc++;
-	snprintf(casptext, sizeof(casptext), "%ix%i", GameCfg.AspectY, GameCfg.AspectX);
+	snprintf(casptext, sizeof(casptext), "%ix%i", static_cast<int>(GameCfg.AspectY), static_cast<int>(GameCfg.AspectX));
 	nm_set_item_input(m[mc], casptext);
 	modes[mc] = 0; mc++;
 	nm_set_item_text(m[mc], ""); mc++; // little space for overview
@@ -1590,7 +1590,7 @@ static int get_absolute_path(char *full_path, const char *rel_path)
 	return 1;
 }
 
-#define SELECT_SONG(t, s)	select_file_recursive(t, GameCfg.CMMiscMusic[s].data(), jukebox_exts, 0, get_absolute_path, GameCfg.CMMiscMusic[s].data())
+#define SELECT_SONG(t, s)	select_file_recursive(t, GameCfg.CMMiscMusic[s], jukebox_exts, 0, get_absolute_path, static_cast<char *>(GameCfg.CMMiscMusic[s]))
 #endif
 
 static int sound_menuset(newmenu *menu,const d_event &event, const unused_newmenu_userdata_t *)
@@ -1677,8 +1677,8 @@ static int sound_menuset(newmenu *menu,const d_event &event, const unused_newmen
 				static const array<file_extension_t, 1> ext_list{"m3u"};		// select a directory or M3U playlist
 				select_file_recursive(
 					"Select directory or\nM3U playlist to\n play level music from" WINDOWS_DRIVE_CHANGE_TEXT,
-									  GameCfg.CMLevelMusicPath.data(), ext_list, 1,	// look in current music path for ext_list files and allow directory selection
-									  get_absolute_path, GameCfg.CMLevelMusicPath.data());	// just copy the absolute path
+					GameCfg.CMLevelMusicPath, ext_list, 1,	// look in current music path for ext_list files and allow directory selection
+					get_absolute_path, static_cast<char *>(GameCfg.CMLevelMusicPath));	// just copy the absolute path
 			}
 			else if (citem == opt_sm_cm_mtype3_file1_b)
 				SELECT_SONG("Select main menu music" WINDOWS_DRIVE_CHANGE_TEXT, SONG_TITLE);
@@ -1791,7 +1791,7 @@ void do_sound_menu()
 	opt_sm_mtype3_lmpath = nitems;
 	nm_set_item_browse(&m[nitems++], "path for level music" BROWSE_TXT);
 
-	nm_set_item_input(m[nitems++], GameCfg.CMLevelMusicPath);
+	nm_set_item_input(m[nitems++], PATH_MAX - 1, GameCfg.CMLevelMusicPath);
 
 	nm_set_item_text(m[nitems++], "");
 
@@ -1814,31 +1814,31 @@ void do_sound_menu()
 	nm_set_item_browse(&m[nitems++], "main menu" BROWSE_TXT);
 
 	opt_sm_cm_mtype3_file1 = nitems;
-	nm_set_item_input(m[nitems++], GameCfg.CMMiscMusic[SONG_TITLE]);
+	nm_set_item_input(m[nitems++], PATH_MAX - 1, GameCfg.CMMiscMusic[SONG_TITLE]);
 
 	opt_sm_cm_mtype3_file2_b = nitems;
 	nm_set_item_browse(&m[nitems++], "briefing" BROWSE_TXT);
 
 	opt_sm_cm_mtype3_file2 = nitems;
-	nm_set_item_input(m[nitems++], GameCfg.CMMiscMusic[SONG_BRIEFING]);
+	nm_set_item_input(m[nitems++], PATH_MAX - 1, GameCfg.CMMiscMusic[SONG_BRIEFING]);
 
 	opt_sm_cm_mtype3_file3_b = nitems;
 	nm_set_item_browse(&m[nitems++], "credits" BROWSE_TXT);
 
 	opt_sm_cm_mtype3_file3 = nitems;
-	nm_set_item_input(m[nitems++], GameCfg.CMMiscMusic[SONG_CREDITS]);
+	nm_set_item_input(m[nitems++], PATH_MAX - 1, GameCfg.CMMiscMusic[SONG_CREDITS]);
 
 	opt_sm_cm_mtype3_file4_b = nitems;
 	nm_set_item_browse(&m[nitems++], "escape sequence" BROWSE_TXT);
 
 	opt_sm_cm_mtype3_file4 = nitems;
-	nm_set_item_input(m[nitems++], GameCfg.CMMiscMusic[SONG_ENDLEVEL]);
+	nm_set_item_input(m[nitems++], PATH_MAX - 1, GameCfg.CMMiscMusic[SONG_ENDLEVEL]);
 
 	opt_sm_cm_mtype3_file5_b = nitems;
 	nm_set_item_browse(&m[nitems++], "game ending" BROWSE_TXT);
 
 	opt_sm_cm_mtype3_file5 = nitems;
-	nm_set_item_input(m[nitems++], GameCfg.CMMiscMusic[SONG_ENDGAME]);
+	nm_set_item_input(m[nitems++], PATH_MAX - 1, GameCfg.CMMiscMusic[SONG_ENDGAME]);
 #endif
 
 	Assert(nitems == SOUND_MENU_NITEMS);
@@ -1846,7 +1846,7 @@ void do_sound_menu()
 	newmenu_do1( NULL, "Sound Effects & Music", nitems, m, sound_menuset, unused_newmenu_userdata, 0 );
 
 #ifdef USE_SDLMIXER
-	if ( ((Game_wind != NULL) && strcmp(old_CMLevelMusicPath.data(), GameCfg.CMLevelMusicPath.data())) || ((Game_wind == NULL) && strcmp(old_CMMiscMusic0.data(), GameCfg.CMMiscMusic[SONG_TITLE].data())) )
+	if ( ((Game_wind != NULL) && strcmp(old_CMLevelMusicPath, GameCfg.CMLevelMusicPath)) || ((Game_wind == NULL) && strcmp(old_CMMiscMusic0, GameCfg.CMMiscMusic[SONG_TITLE])) )
 	{
 		songs_uninit();
 

--- a/similar/main/menu.cpp
+++ b/similar/main/menu.cpp
@@ -354,7 +354,7 @@ int RegisterPlayer()
 		else
 		{
 			// Read the last player's name from config file, not lastplr.txt
-			Players[Player_num].callsign.copy(GameCfg.LastPlayer, CALLSIGN_LEN - 1);
+			Players[Player_num].callsign.copy_lower(GameCfg.LastPlayer, CALLSIGN_LEN - 1);
 		}
 	}
 

--- a/similar/main/songs.cpp
+++ b/similar/main/songs.cpp
@@ -430,10 +430,10 @@ int songs_play_song( int songnum, int repeat )
 
 			Song_playing = -1;
 #if defined(DXX_BUILD_DESCENT_I)
-			int play = songs_play_file(GameCfg.CMMiscMusic[songnum].data(), repeat, NULL);
+			int play = songs_play_file(GameCfg.CMMiscMusic[songnum], repeat, NULL);
 #elif defined(DXX_BUILD_DESCENT_II)
 			int use_credits_track = (songnum == SONG_TITLE && GameCfg.OrigTrackOrder);
-			int play = songs_play_file(GameCfg.CMMiscMusic[songnum].data(),
+			int play = songs_play_file(GameCfg.CMMiscMusic[songnum],
 							  // Play the credits track after the title track and loop the credits track if original CD track order was chosen
 							  use_credits_track ? 0 : repeat,
 							  use_credits_track ? play_credits_track : NULL);
@@ -548,7 +548,7 @@ int songs_play_level_song( int levelnum, int offset )
 
 					// As soon as we start a new level, go to next track
 					if (last_songnum != -1 && songnum != last_songnum)
-						((GameCfg.CMLevelMusicTrack[0]+1>=GameCfg.CMLevelMusicTrack[1])?GameCfg.CMLevelMusicTrack[0]=0:GameCfg.CMLevelMusicTrack[0]++);
+						((GameCfg.CMLevelMusicTrack[0]+1>=GameCfg.CMLevelMusicTrack[1])?GameCfg.CMLevelMusicTrack[0]=0:(GameCfg.CMLevelMusicTrack[0] = GameCfg.CMLevelMusicTrack[0] + 1));
 					last_songnum = songnum;
 				}
 				else if (GameCfg.CMLevelMusicPlayOrder == MUSIC_CM_PLAYORDER_LEVEL)
@@ -556,11 +556,11 @@ int songs_play_level_song( int levelnum, int offset )
 			}
 			else
 			{
-				GameCfg.CMLevelMusicTrack[0] += offset;
+				GameCfg.CMLevelMusicTrack[0] = GameCfg.CMLevelMusicTrack[0] + offset;
 				if (GameCfg.CMLevelMusicTrack[0] < 0)
 					GameCfg.CMLevelMusicTrack[0] = GameCfg.CMLevelMusicTrack[1] + GameCfg.CMLevelMusicTrack[0];
 				if (GameCfg.CMLevelMusicTrack[0] + 1 > GameCfg.CMLevelMusicTrack[1])
-					GameCfg.CMLevelMusicTrack[0] = GameCfg.CMLevelMusicTrack[0] - GameCfg.CMLevelMusicTrack[1];
+					GameCfg.CMLevelMusicTrack[0] = static_cast<int>(GameCfg.CMLevelMusicTrack[0]) - static_cast<int>(GameCfg.CMLevelMusicTrack[1]);
 			}
 
 			Song_playing = -1;


### PR DESCRIPTION
Converts all the descent.cfg values to "archive" cvars. this means that descent.cfg is now merely a script to be `exec`ed at startup, and written out with the generic `cvar_write` function.

list of cvars within the console:

```
]set
DigiVolume: 8
MusicVolume: 8
ReverseStereo: 0
OrigTrackOrder: 1
MusicType: 2
CMLevelMusicPlayOrder: 0
CMLevelMusicTrack0: -1
CMLevelMusicTrack1: -1
CMLevelMusicPath: descent2.m3u
CMMiscMusic0: /Users/bradleyb/Music/iTunes/iTunes Music/Redbook Soundtrack/Descent II, Macintosh CD-ROM/02 Title.mp3
CMMiscMusic1: /Users/bradleyb/Music/iTunes/iTunes Music/Insanity/Descent/03 Outerlimits.mp3
CMMiscMusic2: /Users/bradleyb/Music/iTunes/iTunes Music/Insanity/Descent/04 Close Call.mp3
CMMiscMusic3: /Users/bradleyb/Music/iTunes/iTunes Music/Insanity/Descent/14 Insanity.mp3
CMMiscMusic4: /Users/bradleyb/Music/iTunes/iTunes Music/Redbook Soundtrack/Descent II, Macintosh CD-ROM/03 Crawl.mp3
GammaLevel: 0
LastPlayer: player
LastMission: 
ResolutionX: 640
ResolutionY: 480
AspectX: 3
AspectY: 4
WindowMode: 0
TexFilt: 0
MovieTexFilt: 0
MovieSubtitles: 0
VSync: 0
Multisample: 0
FPSIndicator: 0
GrabInput: 1
```
